### PR TITLE
fix: update시 employee 프로필 이미지 유지

### DIFF
--- a/src/main/java/com/team6/hrbank/service/EmployeeServiceImpl.java
+++ b/src/main/java/com/team6/hrbank/service/EmployeeServiceImpl.java
@@ -118,9 +118,14 @@ public class EmployeeServiceImpl implements EmployeeService {
 
         EmployeePosition position = validateAndParsePosition(request.position());
 
-        FileMetadata newProfileImage = null;
+        FileMetadata newProfileImage = employee.getProfileImage();
+
         if (profileImage != null && !profileImage.isEmpty()) {
             newProfileImage = fileMetadataService.create(profileImage);
+
+            if(employee.getProfileImage()!=null){
+                fileMetadataService.deleteById(employee.getProfileImage().getId());
+            }
         }
         employee.update(request, newDepartment, position, newProfileImage);
 


### PR DESCRIPTION
- 새로운 프로필 이미지가 들어오지 않으면 기존 프로필 유지
- 새로운 프로필 이미지가 들어오면, 기존의 프로필 삭제 후 새로운 프로필 이미지 등록